### PR TITLE
Added files for running with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+---
+version: "2"
+
+services:
+  pdfeditor:
+    container_name: pdfeditor
+    image: mhart/alpine-node:latest
+    volumes:
+      - .:/app
+    working_dir: /app
+    ports:
+      - '127.0.0.1:5000:5000'
+    restart: unless-stopped
+    command: >
+      sh -c 'npm install && npm run build && npm run docker'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public"
+    "start": "sirv public",
+    "docker": "sirv public --host 0.0.0.0 --port 5000"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^2.1.2",


### PR DESCRIPTION
This is a very useful app, thank you!
I'm no docker-compose expert, but I like to run most apps using compose to keep things organized.
With these modifications, the app can now be built and run using `docker-compose up` or `docker-compose up -d` (detached).